### PR TITLE
fix: broken plugin on windows

### DIFF
--- a/packages/vite-vercel/src/plugin.ts
+++ b/packages/vite-vercel/src/plugin.ts
@@ -72,7 +72,9 @@ export const plugin = (options: Options = {}): Plugin => {
         if (!serverNode) return next()
 
         try {
-          const middleware = await server.ssrLoadModule(`/@fs${middlewarePath}`)
+          const middleware = await server.ssrLoadModule(
+            `/@fs${middlewarePath?.replace(/^[\\/]?/, "/")}`,
+          )
           const request = serverNode.createRequest(req)
           const event = serverNode.createFetchEvent(request)
           let response: Response = await middleware.default(request, event)


### PR DESCRIPTION
As far as I can tell, if the middleware path is on a windows machine you'll not start with a `/` and so the start no longer matches the expected Vite pattern. Given change should include it if it doesn't add one automatically